### PR TITLE
Updates to tag-line

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -58,8 +58,7 @@ defaults:
     social: 
     layout: team
 url: https://www.openownership.org
-description: Building an open register of global beneficial ownership in the public
-  interest.
+description: Driving the global shift towards transparency over who owns and controls companies.
 permalink: pretty
 exclude:
 - bower.json


### PR DESCRIPTION
An old tag-line is being exposed as a default description when pages do not set them. This PR updates the default description line exposed in page metadata.