### PR TITLE
Add a partner with us page

### DIFF
--- a/_posts/2016-11-22-the-first-steps.markdown
+++ b/_posts/2016-11-22-the-first-steps.markdown
@@ -5,7 +5,7 @@ permalink: news/the-first-steps/
 categories:
 - blogs
 tags:
-- 1-1 technical assistance
+- partnering with us
 - the beneficial ownership data standard
 image: "/uploads/first-steps.jpg"
 author: Hera Hussain
@@ -24,4 +24,3 @@ But the creation of such a register cannot and should not be done in isolation. 
 *These include [Global Witness](https://www.globalwitness.org/), [Open Contracting Partnership](http://www.open-contracting.org/), [Web Foundation](http://webfoundation.org/), [Transparency International](https://www.transparency.org.uk/), and the [B Team](http://bteam.org/), as well as [OpenCorporates](opencorporates.com).
 
 ![oo-mountains.jpg](/uploads/oo-mountains.jpg)
-

--- a/_posts/2017-03-31-faqs-openownership.markdown
+++ b/_posts/2017-03-31-faqs-openownership.markdown
@@ -5,7 +5,7 @@ permalink: news/faqs-openownership/
 categories:
 - blogs
 tags:
-- 1-1 technical assistance
+- partnering with us
 - the beneficial ownership data standard
 - the openownership pilot program
 - private sector engagement

--- a/_posts/2017-09-07-not-just-public-but-useful-the-right-way-to-set-up-a-beneficial-ownership-register.markdown
+++ b/_posts/2017-09-07-not-just-public-but-useful-the-right-way-to-set-up-a-beneficial-ownership-register.markdown
@@ -35,7 +35,7 @@ By adopting the OpenOwnership standard and international best practice on data, 
 
 * Linking to other datasets: Just as when it’s connected across borders, beneficial ownership data is more powerful when it’s connected across different areas of government. By linking beneficial ownership data to procurement, licensing, lobbying and political donations data, for example, we can bring transparency to areas of government where corruption is often endemic.
 
-## Partner with us
+## partnering with us
 
 OpenOwnership is actively partnering with governments and providing support to implement the standard. Meanwhile, we have built the [world’s first global beneficial ownership register](https://register.openownership.org/) — now in beta — linking beneficial ownership data from worldwide corporate registries and other sources.
 

--- a/_posts/2018-01-03-ukrainian-beneficial-ownership-data-now-available.markdown
+++ b/_posts/2018-01-03-ukrainian-beneficial-ownership-data-now-available.markdown
@@ -6,7 +6,7 @@ categories:
 - news
 tags:
 - the openownership pilot program
-- 1-1 technical assistance
+- partnering with us
 - the beneficial ownership data standard
 - ukraine
 - openownership register

--- a/_posts/2018-04-04-beneficial-ownership-transparency-in-ukraine-whats-next.markdown
+++ b/_posts/2018-04-04-beneficial-ownership-transparency-in-ukraine-whats-next.markdown
@@ -6,7 +6,7 @@ categories:
 - blogs
 tags:
 - the openownership pilot program
-- 1-1 technical assistance
+- partnering with us
 - ukraine
 - openownership register
 image: "/uploads/ukraine.jpg"

--- a/_posts/2018-10-22-ukrainemou.markdown
+++ b/_posts/2018-10-22-ukrainemou.markdown
@@ -6,7 +6,7 @@ permalink: news/ukrainemou/
 categories:
 - news
 tags:
-- 1-1 technical assistance
+- partnering with us
 - the beneficial ownership data standard
 - ukraine
 image: "/uploads/ukraine-signs.jpg"

--- a/_posts/2018-12-18-openownership-in-kiev.markdown
+++ b/_posts/2018-12-18-openownership-in-kiev.markdown
@@ -5,7 +5,7 @@ permalink: news/openownership-in-kiev/
 categories:
 - blogs
 tags:
-- 1-1 technical assistance
+- partnering with us
 - the openownership pilot program
 - private sector engagement
 - the beneficial ownership data standard

--- a/_posts/2019-10-30-armenia-signs-mou-with-openownership.markdown
+++ b/_posts/2019-10-30-armenia-signs-mou-with-openownership.markdown
@@ -6,7 +6,7 @@ categories:
 - news
 tags:
 - the beneficial ownership leadership group
-- 1-1 technical assistance
+- partnering with us
 image: "/uploads/EICcuoNXYAAqwNE.jpg"
 description: Signing ceremony and technical workshop in Yerevan launches start of
   a partnership between OpenOwnership and the Armenian Government, taking a step towards

--- a/_what-we-do/1-1-technical-assistance.markdown
+++ b/_what-we-do/1-1-technical-assistance.markdown
@@ -1,17 +1,1 @@
----
-title: 1-1 technical assistance
-date: 2018-08-17 07:36:00 Z
-layout: page-what-we-do
----
-
-Helpdesk support is provided to governments or organisations implementing, or considering implementing, beneficial ownership disclosure regimes using the Beneficial Ownership Data Standard.
-
-The Helpdesk gives hands-on advice on designing data collection processes and integrating beneficial ownership data with existing systems. It also provides guidance on policy requirements. Later in the implementation journey, the Helpdesk can help to assess whether published data complies with the Standard.
-
-The Helpdesk is also available to those looking for a broader range of support. We can help you if you:
-
-* Are civil society, and have a question about advocating for beneficial ownership transparency in your jurisdiction
-* Are a user of the OpenOwnership Register and want to know more about using the data
-* Are a data publisher, and would like light touch guidance on topics within our expertise: collecting and storing beneficial ownership data, developing forms and processes for collection, compatibility with data protection frameworks, verification, compliance, enforcement, and user engagement.
-
-If you have a query please contact the helpdesk at [support@openownership.org](support@openownership.org)
+<head><meta http-equiv="refresh" content="0;url=/what-we-do/partnering-with-us/"></head>

--- a/_what-we-do/partnering-with-us.markdown
+++ b/_what-we-do/partnering-with-us.markdown
@@ -1,0 +1,64 @@
+---
+title: Partnering with us
+date: 2020-04-07 14:24:00 Z
+layout: page-what-we-do
+---
+
+OpenOwnership is a World Bank and UK government-funded organisation that offers technical assistance to countries seeking to collect, compile and publish data on who ultimately controls companies operating in their jurisdiction. By providing easy access to technical knowledge and peer-review, OO supports effective implementation and helps remove barriers to the collection and publication of beneficial ownership data.
+
+OpenOwnership specialises in providing integrated support across the whole range of policy, legal, systems and technology issues involved in establishing beneficial ownership registers. For those just starting out on their implementation journey, OO can also advise on the implications of creating open registers and the numerous advantages they bring. These include supporting diverse national policy goals, from improving the business environment to meeting FATF and OECD standards, as well as tackling corruption and money laundering.
+
+## Our work
+
+OpenOwnership offers a tailored and highly collaborative approach to technical assistance, providing bespoke guidance that fits the specific needs of each individual country’s context. We recognise that there is no one-size-fits-all solution to the challenges involved in implementing beneficial ownership disclosure and work closely with our partner agencies to help them deliver impact in-country.
+
+OpenOwnership is recognised internationally as a leading expert organisation in this field and, in 2019, partnered with the [Open Government Partnership](https://www.opengovpartnership.org/) to convene the Beneficial Ownership Leadership Group. This initiative brings together national governments across the globe that have committed to share learning and drive continued development of best practice in the field of beneficial ownership transparency.
+
+Previous technical assistance projects have included sector-specific work, such as extractive industry beneficial ownership registers, as well as cross-sectoral and national initiatives. OO has provided comprehensive assistance to government agencies in Ukraine – among the first countries to create a public beneficial ownership register – as well as to those in Armenia, Kyrgyz Republic and elsewhere. OO has also advised Kenya on the development of its beneficial ownership legislation and helped Nigeria create its disclosure forms and associated laws, among many other projects.
+
+## How we can help
+
+OpenOwnership has collated knowledge from multiple country contexts to create a suite of implementation guides, templates and tools that can be used to streamline register creation and data publication. The emerging best practice on beneficial ownership transparency is outlined in a range of freely-available guides, including:
+
+* The **Beneficial Ownership Data Standard**, a structured template for producing high quality, machine readable beneficial ownership data;
+* Our **implementation guide** that helps implementers navigate the full journey from considering beneficial ownership transparency right through to publishing data on a public register;
+* **Template forms** for collecting beneficial ownership information; and
+* Our **legal framework and data systems reviewer tools** , which can help identify required reforms prior to the creation of centralised registers.
+
+Via our **helpdesk**, we also provide support to governments or organisations implementing, or considering implementing, a beneficial ownership disclosure framework using the [Beneficial Ownership Data Standard](https://standard.openownership.org/en/latest/). The helpdesk service provides practical advice on designing data collection processes; integrating beneficial ownership data with existing systems, addressing policy queries; and assessing whether published data complies with emerging best practice.
+
+For a more limited number of countries, OO offers **enhanced support** by tailoring various tools to fit the individual context and assisting with their implementation. Our highest level of programmatic assistance generally includes: a holistic evaluation of the technical, administrative, and policy frameworks; providing bespoke recommendations on how to produce high-quality beneficial ownership data; and implementation support in the form of technical expertise and access to our networks.
+
+The exact support OO provides to our high-engagement countries is always tailored to respond to the most pressing needs. To date this has included: detailed legal and technical document reviews; in-country and online training and workshops; customised guidance on data verification best practices; or technical support during the data import and user testing phases. The aim of all these initiatives is to provide practical and realisable technical recommendations that facilitate the creation of a sustainable beneficial ownership regime containing high-quality, and highly usable, data.
+
+## Partnering queries
+
+### What are the advantages of beneficial ownership transparency?
+
+Anonymous shell companies are the main vehicle used to evade billions of dollars in tax revenues. They are also used to move illicit funds – from laundering money for human trafficking and the drug trade to funding terror groups and criminal gangs. By removing the ability of the criminally inclined to hide their earnings behind opaque corporate structures, beneficial ownership registers help governments to crackdown on these illicit activities.
+
+In addition, transparent company ownership creates a better environment for business by increasing market competitiveness. Open registers allow companies to better vet prospective partners, clients and suppliers, conduct enhanced due diligence and manage risk exposure. Investors benefit from reducing risk exposure when making new investments by helping create a favourable environment for inward investment.
+
+### Does OpenOwnership only assist countries that are working towards public beneficial ownership registers?
+
+OpenOwnership [advocates for open beneficial ownership registers](https://www.openownership.org/uploads/the-case-for-public-beneficial-ownership.pdf) as these generate the largest benefits for both the business environment and the efforts to clamp down on financial crimes, such as tax evasion, corruption and money laundering. While generally prioritising partnering with countries that are working towards public registers (either at the national or sectoral level), OO recognises that this is an emerging policy field and that implementation of any centralised register still presents a series of significant challenges. As such, OO remains open to partnering with agencies that are working on compiling or improving their central beneficial ownership register, even if there are no immediate plans to make the data publicly available.
+
+### What type of countries and organisations does OpenOwnership work with? How much support can you provide?
+
+Anyone is able to access our library of [practical resources](https://www.openownership.org/resources/) which includes implementation guides, templates and tools that can be used to streamline the process of register creation and data publication. Implementing agencies within government, and those supporting implementation from within civil society, can also use our free helpdesk to gain advice on designing data collection processes and integrating beneficial ownership data with their existing systems. Via the helpdesk, organisations can also ask for guidance on policy requirements or information on whether published data complies with our suggested best practice model detailed in our [Beneficial Ownership Data Standard](https://standard.openownership.org/en/v0-2-0/).
+
+A greater level of free technical assistance and enhanced support is also available to a more limited number of countries, in accordance with our funding restrictions and strategic priorities. We are very happy to consider any requests for enhanced support, so please do not hesitate to contact us at [support@openownership.org](https://www.openownership.org/what-we-do/1-1-technical-assistance/support@openownership.org) for more information or to discuss your requirements.
+
+### What is the cost of working with OpenOwnership? How is your work funded?
+
+OpenOwnership receives funding from international donors, including the UK Department for International Development and the World Bank, which finances the majority of our international technical assistance work. Thanks to the ongoing support of these donors, OO has been able to deliver a number of important technical assistance initiatives at no (or at a heavily subsidised) cost to the beneficiary institutions.
+
+Countries that are not eligible for Official Development Assistance (ODA) can still access our helpdesk as well as our range of free tools and implementation guides. However, we will be able to provide enhanced support to these jurisdictions only in a more limited set of circumstances. Indeed, one of the first stages of assistance we may provide such countries could include guidance on securing funding to cover the cost of a more in-depth technical assistance programme.
+
+### We are currently only considering whether to create a beneficial ownership register. Can we still request assistance from OpenOwnership?
+
+Yes. OpenOwnership remains committed to working with agencies that are at all stages of the [implementation journey](https://www.openownership.org/guide/). Whether you are considering a register and unsure of its benefits, have committed to creating a register but are unclear of how to proceed, or are looking for advice on technical and legal aspects of implementation, OO can offer tools and advice that will make the implementation process more efficient and effective.
+
+## Get in touch
+
+We are actively seeking to expand our donor-funded in-country support and are looking for new partners from Latin America, Asia, Africa and beyond. If you are interested in partnering with OpenOwnership to advance beneficial ownership transparency in your country, please contact [support@openownership.org](mailto:support@openownership.org), to discuss your country's needs and the support we could provide.

--- a/_what-we-do/partnering-with-us.markdown
+++ b/_what-we-do/partnering-with-us.markdown
@@ -4,7 +4,7 @@ date: 2020-04-07 14:24:00 Z
 layout: page-what-we-do
 ---
 
-OpenOwnership is a World Bank and UK government-funded organisation that offers technical assistance to countries seeking to collect, compile and publish data on who ultimately controls companies operating in their jurisdiction. By providing easy access to technical knowledge and peer-review, OO supports effective implementation and helps remove barriers to the collection and publication of beneficial ownership data.
+OpenOwnership is the leading global hub for company ownership information and advice, from drafting laws to verifying data and making it work in practice. We offer technical assistance to countries seeking to collect, compile and publish data on who ultimately controls companies operating in their jurisdiction. By providing easy access to technical knowledge and peer-review, OO supports effective implementation and helps remove barriers to the collection and publication of beneficial ownership data.
 
 OpenOwnership specialises in providing integrated support across the whole range of policy, legal, systems and technology issues involved in establishing beneficial ownership registers. For those just starting out on their implementation journey, OO can also advise on the implications of creating open registers and the numerous advantages they bring. These include supporting diverse national policy goals, from improving the business environment to meeting FATF and OECD standards, as well as tackling corruption and money laundering.
 

--- a/what-we-do.md
+++ b/what-we-do.md
@@ -36,15 +36,16 @@ services:
     Slovak Republic.
   button: Find out more
   link: "/what-we-do/the-beneficial-ownership-leadership-group/"
-- title: 1-1 technical assistance
+- title: Partnering with us
   icon: one-on-one
-  text: Whether this occurs within the pilot program or on a bespoke basis, we are
-    committed to providing technical assistance to beneficial ownership data publishers
-    in both the public and private sectors. Through our helpdesk we can answer questions
-    about technical implementation and provide a hub for sharing best practice and
-    learnings from different implementations.
+  text: We specialise in providing integrated support across the whole
+    range of policy, legal, systems and technology issues involved in establishing
+    beneficial ownership registers. We offer bespoke guidance that fits the specific
+    needs of each individual country’s context. We recognise that there is no
+    one-size-fits-all solution and work closely with our partner agencies to help
+    them deliver impact in-country.
   button: Find out more
-  link: "/what-we-do/1-1-technical-assistance/"
+  link: "/what-we-do/partnering-with-us/"
 - title: Private sector engagement
   icon: private-sector
   text: We are encouraging corporations and financial institutions to use the OpenOwnership
@@ -63,4 +64,3 @@ services:
   link: "/resources/"
 layout: what-we-do
 ---
-


### PR DESCRIPTION
This replaces the 1-1 tech assistance page because it's basically the same but with much more content. I've added a redirect from that page, and updated all the old tagged posts to point at the new page for related content.