### PR TITLE
Fixing get in touch link in Framework

### DIFF
--- a/_layouts/framework.html
+++ b/_layouts/framework.html
@@ -57,7 +57,7 @@ layout: default
           <hr/>
           <h2>Learn more</h2>
           <p>
-            We will shortly be publishing new resources that provide detail on putting this principle into practice. In the meantime, please <a href="/what-we-do/1-1-technical-assistance/">get in touch with our technical assistance team</a> for support and advice.
+            We will shortly be publishing new resources that provide detail on putting this principle into practice. In the meantime, please <a href="mailto:support@openownership.org">get in touch with our technical assistance team</a> for support and advice.
           </p>
         {% endif %}
       </div>


### PR DESCRIPTION
Replacing link to contact page with mailto link following feedback from Pete.

In future this should be changed back to link to a contact page. 