### PR TITLE
Update map GH workflow to new GH requirements

### DIFF
--- a/.github/workflows/update_map.yml
+++ b/.github/workflows/update_map.yml
@@ -13,7 +13,7 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v2
     - name: Set up Python 3.7
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v2
       with:
         python-version: 3.7
     - name: Install dependencies

--- a/.github/workflows/update_map.yml
+++ b/.github/workflows/update_map.yml
@@ -26,7 +26,7 @@ jobs:
         NOTION_EMAIL: ${{ secrets.NOTION_EMAIL }}
         NOTION_PASSWORD: ${{ secrets.NOTION_PASSWORD }}
     - name: Make a pull request
-      uses: peter-evans/create-pull-request@v2.8.0
+      uses: peter-evans/create-pull-request@v3
       with:
         branch: automated-map-update
         branch-suffix: timestamp


### PR DESCRIPTION
We mainly use off the shelf steps in our actions, but recent GH changes meant these were no longer working. This just bumps the required dependencies to make things work again.